### PR TITLE
Release v. 1.7 of registers-sml containing fix in PR #41

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>uk.gov.ons</groupId>
     <artifactId>registers-sml</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <packaging>jar</packaging>
     <name>Registers Statistical Method Library</name>
     <description>Library of statistics methods for Registers</description>


### PR DESCRIPTION
This release contains a fix for the issue that only one sample was being
returned by sbr-sampling-service