### PR TITLE
Allow deployment to a maven repository on the on-premise Artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>uk.gov.ons</groupId>
     <artifactId>registers-sml</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Registers Statistical Method Library</name>
     <description>Library of statistics methods for Registers</description>
@@ -13,7 +13,7 @@
         <url>https://github.com/ONSdigital/registers-sml</url>
         <connection>scm:git:git://github.com/ONSdigital/registers-sml.git</connection>
         <developerConnection>scm:git:git@github.com:ONSdigital/registers-sml.git</developerConnection>
-    <tag>v1.8</tag>
+    <tag>HEAD</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,18 @@
 
     <groupId>uk.gov.ons</groupId>
     <artifactId>registers-sml</artifactId>
-    <version>1.7</version>
+    <version>1.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Registers Statistical Method Library</name>
     <description>Library of statistics methods for Registers</description>
     <url>https://github.com/ONSdigital/registers-sml</url>
+
+    <scm>
+        <url>https://github.com/ONSdigital/registers-sml</url>
+        <connection>scm:git:git://github.com/ONSdigital/registers-sml.git</connection>
+        <developerConnection>scm:git:git@github.com:ONSdigital/registers-sml.git</developerConnection>
+  </scm>
+
 
     <properties>
         <bintray.org>ons</bintray.org>
@@ -25,14 +32,22 @@
 
     <distributionManagement>
         <repository>
-                <id>central</id>
-                <name>ONS Artifactory-releases</name>
-                <url>http://art-p-01/artifactory/LR_Registers-Maven-Releases</url>
+	     <id>central</id>
+	     <name>ONS Artifactory-releases</name>
+	     <url>http://art-p-01/artifactory/LR_Registers-Maven-Releases</url>
         </repository>
     </distributionManagement>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,9 @@
 
     <distributionManagement>
         <repository>
-            <id>bintray-ONS</id>
-            <url>https://api.bintray.com/maven/${bintray.org}/${bintray.repo}/${bintray.package}/;publish=1</url>
+                <id>central</id>
+                <name>ONS Artifactory-releases</name>
+                <url>http://art-p-01/artifactory/LR_Registers-Maven-Releases</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>uk.gov.ons</groupId>
     <artifactId>registers-sml</artifactId>
-    <version>1.8-SNAPSHOT</version>
+    <version>1.8</version>
     <packaging>jar</packaging>
     <name>Registers Statistical Method Library</name>
     <description>Library of statistics methods for Registers</description>
@@ -13,6 +13,7 @@
         <url>https://github.com/ONSdigital/registers-sml</url>
         <connection>scm:git:git://github.com/ONSdigital/registers-sml.git</connection>
         <developerConnection>scm:git:git@github.com:ONSdigital/registers-sml.git</developerConnection>
+    <tag>v1.8</tag>
   </scm>
 
 


### PR DESCRIPTION
This was required to align with the requirement that releases first be
done to the on-network Artifactory and then promoted to Bintray from
Artifactory

Task: REG-2207