### PR TITLE
Correct license attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 ONS Digital
+Copyright (c) Crown Copyright (Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Corrects the copyright notice in the license file to correctly read `Crown Copyright (Office for National Statistics)` (no such entity as _ONSDigital_)